### PR TITLE
Fix format query when cursors are empty (fixes Repo.all with limit)

### DIFF
--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -237,6 +237,9 @@ defmodule Mongo.Ecto.Connection do
   defp format_query(%Query{action: :kill_cursors, extra: coll}, [cursors]) do
     ["KILL_CURSORS", format_part("cursor_ids", cursors)]
   end
+  defp format_query(%Query{action: :kill_cursors, extra: coll}, []) do
+    ["KILL_CURSORS", format_part("cursor_ids", [])]
+  end
 
   defp format_part(name, value) do
     [" ", name, "=" | inspect(value)]

--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -397,6 +397,9 @@ defmodule Mongo.Ecto.NormalizedQuery do
   defp pair({:in, _, [lhs, {{:., _, _}, _, _} = rhs]}, params, pk, query, place) do
     {field(rhs, pk, query, place), value(lhs, params, pk, query, place)}
   end
+  defp pair({:in, _, [{{:., _, _}, [], []} = lhs, rhs]}, params, pk, query, place) do
+    {field(lhs, pk, query, place), ["$in": rhs]}
+  end
   defp pair({op, _, [left, right]}, params, pk, query, place) when op in @binary_ops do
     {field(left, pk, query, place), [{binary_op(op), value(right, params, pk, query, place)}]}
   end

--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -403,6 +403,9 @@ defmodule Mongo.Ecto.NormalizedQuery do
   defp pair({op, _, [left, right]}, params, pk, query, place) when op in @binary_ops do
     {field(left, pk, query, place), [{binary_op(op), value(right, params, pk, query, place)}]}
   end
+  defp pair({:not, _, [{:in, _, [left, {:^, _, [0, 0]}]}]}, params, pk, query, place) do
+    {field(left, pk, query, place), ["$nin": []]}
+  end
   defp pair({:not, _, [{:in, _, [left, {:^, _, [ix, len]}]}]}, params, pk, query, place) do
     args =
       ix..ix+len-1

--- a/test/mongo_ecto/normalized_query_new_test.exs
+++ b/test/mongo_ecto/normalized_query_new_test.exs
@@ -247,8 +247,14 @@ defmodule Mongo.Ecto.NormalizedQueryNewTest do
     query = Schema |> where([r], r.x in [2]) |> normalize
     assert_fields query, query: %{x: ["$in": [2]]}
 
+    query = Schema |> where([r], r.x in []) |> normalize
+    assert_fields query, query: %{x: ["$in": []]}
+
     query = Schema |> where([r], not r.x in [2, 3]) |> normalize
     assert_fields query, query: %{x: ["$nin": [2, 3]]}
+
+    query = Schema |> where([r], not(r.x in ^[])) |> normalize
+    assert_fields query, query: %{x: ["$nin": []]}
   end
 
   test "order by" do

--- a/test/mongo_ecto/normalized_query_new_test.exs
+++ b/test/mongo_ecto/normalized_query_new_test.exs
@@ -243,6 +243,12 @@ defmodule Mongo.Ecto.NormalizedQueryNewTest do
 
     query = Schema |> where([r], not (r.x == 42)) |> normalize
     assert_fields query, query: %{x: ["$ne": 42]}
+
+    query = Schema |> where([r], r.x in [2]) |> normalize
+    assert_fields query, query: %{x: ["$in": [2]]}
+
+    query = Schema |> where([r], not r.x in [2, 3]) |> normalize
+    assert_fields query, query: %{x: ["$nin": [2, 3]]}
   end
 
   test "order by" do

--- a/test/mongo_ecto_test.exs
+++ b/test/mongo_ecto_test.exs
@@ -89,6 +89,14 @@ defmodule Mongo.EctoTest do
     assert 10 == TestRepo.one(query)
   end
 
+
+  test "limit" do
+    TestRepo.insert!(%Post{visits: 15})
+    TestRepo.insert!(%Post{visits: 10})
+
+    assert [_, _] = from(p in Post, limit: 2) |> TestRepo.all
+  end
+
   # test "partial update in map" do
   #   post = TestRepo.insert!(%Post{meta: %{author: %{name: "michal"}, other: "value"}})
   #   TestRepo.update_all(Post, set: [meta: change_map("author.name", "michal")])


### PR DESCRIPTION
A query used in the new tests called:
`format_query(..., [])` 
which didn't match `[cursors]` in 
`defp format_query(%Query{action: :kill_cursors, extra: coll}, [cursors]) do`