### PR TITLE
Fix in keyword for where clause

### DIFF
--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -397,6 +397,9 @@ defmodule Mongo.Ecto.NormalizedQuery do
   defp pair({:in, _, [lhs, {{:., _, _}, _, _} = rhs]}, params, pk, query, place) do
     {field(rhs, pk, query, place), value(lhs, params, pk, query, place)}
   end
+  defp pair({:in, _, [{{:., _, _}, [], []} = lhs, rhs]}, params, pk, query, place) do
+    {field(lhs, pk, query, place), ["$in": rhs]}
+  end
   defp pair({op, _, [left, right]}, params, pk, query, place) when op in @binary_ops do
     {field(left, pk, query, place), [{binary_op(op), value(right, params, pk, query, place)}]}
   end

--- a/lib/mongo_ecto/normalized_query.ex
+++ b/lib/mongo_ecto/normalized_query.ex
@@ -403,6 +403,9 @@ defmodule Mongo.Ecto.NormalizedQuery do
   defp pair({op, _, [left, right]}, params, pk, query, place) when op in @binary_ops do
     {field(left, pk, query, place), [{binary_op(op), value(right, params, pk, query, place)}]}
   end
+  defp pair({:not, _, [{:in, _, [left, {:^, _, [0, 0]}]}]}, params, pk, query, place) do
+    {field(left, pk, query, place), ["$nin": []]}
+  end
   defp pair({:not, _, [{:in, _, [left, {:^, _, [ix, len]}]}]}, params, pk, query, place) do
     args =
       ix..ix+len-1

--- a/test/mongo_ecto/normalized_query_new_test.exs
+++ b/test/mongo_ecto/normalized_query_new_test.exs
@@ -247,8 +247,14 @@ defmodule Mongo.Ecto.NormalizedQueryNewTest do
     query = Schema |> where([r], r.x in [2]) |> normalize
     assert_fields query, query: %{x: ["$in": [2]]}
 
+    query = Schema |> where([r], r.x in []) |> normalize
+    assert_fields query, query: %{x: ["$in": []]}
+
     query = Schema |> where([r], not r.x in [2, 3]) |> normalize
     assert_fields query, query: %{x: ["$nin": [2, 3]]}
+
+    query = Schema |> where([r], not(r.x in ^[])) |> normalize
+    assert_fields query, query: %{x: ["$nin": []]}
   end
 
   test "order by" do

--- a/test/mongo_ecto/normalized_query_new_test.exs
+++ b/test/mongo_ecto/normalized_query_new_test.exs
@@ -243,6 +243,12 @@ defmodule Mongo.Ecto.NormalizedQueryNewTest do
 
     query = Schema |> where([r], not (r.x == 42)) |> normalize
     assert_fields query, query: %{x: ["$ne": 42]}
+
+    query = Schema |> where([r], r.x in [2]) |> normalize
+    assert_fields query, query: %{x: ["$in": [2]]}
+
+    query = Schema |> where([r], not r.x in [2, 3]) |> normalize
+    assert_fields query, query: %{x: ["$nin": [2, 3]]}
   end
 
   test "order by" do


### PR DESCRIPTION
Fixes following queries:

`Schema |> where([r], r.id in [2])` 
`Schema |> where([r], r.id in ^[])`  - didn't work for empty list with pin operator