### PR TITLE
Fix ecto migrate

### DIFF
--- a/lib/mongo_ecto.ex
+++ b/lib/mongo_ecto.ex
@@ -422,7 +422,7 @@ defmodule Mongo.Ecto do
     {_, opts} = repo.__pool__
     with {:ok, pool} <- DBConnection.ensure_all_started(opts, type),
          {:ok, mongo} <- Application.ensure_all_started(:mongodb, type),
-      do: {:ok, pool ++ [mongo]}
+      do: {:ok, pool ++ mongo}
   end
 
   @doc false

--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -13,12 +13,18 @@ defmodule Mongo.Ecto.Connection do
   def storage_down(opts) do
     opts = Keyword.put(opts, :pool, DBConnection.Connection)
 
+    {:ok, pid} = case Application.ensure_started(:mongodb)  do
+      :ok -> {:ok, nil}
+      {:error, reason} -> Mongo.App.start(nil, nil)
+      pid -> pid
+    end
     {:ok, conn} = Mongo.start_link(opts)
 
     try do
       Mongo.command!(conn, dropDatabase: 1)
       :ok
     after
+      if pid, do: Supervisor.stop(pid)
       GenServer.stop(conn)
     end
   end


### PR DESCRIPTION
Fix for two commands: ecto.drop and ecto.migrate:

ecto.drop issue:
```
21:34:27.235 [error] GenServer #PID<0.1276.0> terminating
** (stop) exited in: GenServer.call(Mongo.Monitor, {:add_conn, #PID<0.1276.0>, nil, 4}, 5000)
    ** (EXIT) no process
    (elixir) lib/gen_server.ex:596: GenServer.call/3
    lib/mongo/protocol.ex:34: Mongo.Protocol.connect/2
    lib/db_connection/connection.ex:134: DBConnection.Connection.connect/2
    lib/connection.ex:622: Connection.enter_connect/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: nil
State: Mongo.Protocol
```

ecto.migrate issue:
```
** (FunctionClauseError) no function clause matching in Application.ensure_all_started/2
    (elixir) lib/application.ex:322: Application.ensure_all_started([:connection, :db_connection, :mongodb], :temporary)
    (ecto) lib/mix/ecto.ex:123: anonymous fn/2 in Mix.Ecto.restart_apps_if_migrated/2
    (elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/mix/ecto.ex:122: Mix.Ecto.restart_apps_if_migrated/2
    (elixir) lib/enum.ex:651: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:651: Enum.each/2
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/task.ex:328: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:261: Mix.Task.run/2
    (mix) lib/mix/task.ex:328: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:261: Mix.Task.run/2
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:363: Code.require_file/2
```