### PR TITLE
Fix logging

### DIFF
--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -243,6 +243,9 @@ defmodule Mongo.Ecto.Connection do
   defp format_query(%Query{action: :kill_cursors, extra: coll}, [cursors]) do
     ["KILL_CURSORS", format_part("cursor_ids", cursors)]
   end
+  defp format_query(%Query{action: :kill_cursors, extra: coll}, []) do
+    ["KILL_CURSORS", format_part("cursor_ids", "")]
+  end
 
   defp format_part(name, value) do
     [" ", name, "=" | inspect(value)]

--- a/lib/mongo_ecto/connection.ex
+++ b/lib/mongo_ecto/connection.ex
@@ -237,8 +237,11 @@ defmodule Mongo.Ecto.Connection do
     ["REPLACE", format_part("coll", coll), format_part("filter", filter),
      format_part("document", doc)]
   end
-  defp format_query(%Query{action: :find_rest, extra: coll}, [cursor]) do
+  defp format_query(%Query{action: :get_more, extra: coll}, [cursor]) do
     ["GET_MORE", format_part("coll", coll), format_part("cursor_id", cursor)]
+  end
+  defp format_query(%Query{action: :get_more, extra: coll}, []) do
+    ["GET_MORE", format_part("coll", coll), format_part("cursor_id", "")]
   end
   defp format_query(%Query{action: :kill_cursors, extra: coll}, [cursors]) do
     ["KILL_CURSORS", format_part("cursor_ids", cursors)]


### PR DESCRIPTION
Fix for couple logging cases which failed for me:

1. Query with limit greater than 1
2. Query with GET_MORE command - when query returns too many results, looks like this:

```
18:00:33.934 [debug] QUERY OK db=45.9ms decode=238.0ms
GET_MORE coll={"your_collection", 1556697918457} cursor_id="" []
18:00:35.062 [debug] QUERY OK db=97.2ms decode=328.3ms
GET_MORE coll={"your_collection", 1556697918457} cursor_id="" []
18:00:35.672 [debug] QUERY OK db=17.0ms decode=273.7ms
GET_MORE coll={"your_collection", 1556697918457} cursor_id="" []
18:00:36.315 [debug] QUERY OK db=22.7ms decode=323.9ms
GET_MORE coll={"your_collection", 1556697918457} cursor_id="" []
...
```