### PR TITLE
fixed typo for :eror in change.ex

### DIFF
--- a/lib/mongo_ecto/change.ex
+++ b/lib/mongo_ecto/change.ex
@@ -22,7 +22,7 @@ defmodule Mongo.Ecto.ChangeMap do
   Casts to database format
   """
   def cast(%__MODULE__{} = value), do: {:ok, value}
-  def cast(_), do: :eror
+  def cast(_), do: :error
 
   @doc """
   Converts to a database format
@@ -60,7 +60,7 @@ defmodule Mongo.Ecto.ChangeArray do
   Casts to database format
   """
   def cast(%__MODULE__{} = value), do: {:ok, value}
-  def cast(_), do: :eror
+  def cast(_), do: :error
 
   @doc """
   Converts to a database format


### PR DESCRIPTION
This changeset fixes a typo in file change.ex for :eror instead of :error