### PR TITLE
Do not truncate MongoDB views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ after_script:
 
 env:
   matrix:
-    - MONGOVERSION=2.4.14
     - MONGOVERSION=2.6.12
-    - MONGOVERSION=3.0.12
-    - MONGOVERSION=3.2.10
+    - MONGOVERSION=3.0.15
+    - MONGOVERSION=3.2.21
+    - MONGOVERSION=3.4.18

--- a/test/mongo_ecto_test.exs
+++ b/test/mongo_ecto_test.exs
@@ -16,8 +16,15 @@ defmodule Mongo.EctoTest do
 
   test "truncate/2" do
     TestRepo.insert!(%Post{})
+    case System.get_env("MONGOVERSION") do
+      version when version in ["2.6.12", "3.0.15"] ->
+        nil
+      _ ->
+        Mongo.Ecto.command(TestRepo, %{create: "view", viewOn: "posts", pipeline: []}) # test with Views
+    end
 
     Mongo.Ecto.truncate(TestRepo)
+
     assert [] == TestRepo.all(Post)
   end
 


### PR DESCRIPTION
Hi!

When I call `Mongo.Ecto.truncate/2`, it fails with the following error in case if there is a MongoDB [View](https://docs.mongodb.com/manual/core/views/) in a database:

```
(Mongo.Error) Namespace ecto_test.view is a view, not a collection 166
```

My changes exclude Views from the collection list to avoid trying to truncate them since these are read-only collections. Initially, I wanted to use `list_collections/2` but it returns a list of collection names as strings, so it is not possible to filter out Views after that.

MongoDB Views were introduced in version 3.4.